### PR TITLE
Modifying build-linux.sh to support make-archive.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ For a general purpose static library builder please go to the upstream repo.
 
 3. Install dependencies `$ pip install -r requirements.txt`
 
-4. Run `./convert-model-to-ort.sh model.onnx` on Mac or `.\convert-model-to-ort.bat model.onnx` on Windows
+4. For Mac or Linux, run `./convert-model-to-ort.sh model.onnx`. For Windows, run `.\convert-model-to-ort.bat model.onnx`
 
-5. Run `./build-mac.sh model.required_operators_and_types.with_runtime_opt.config` on Mac or `.\build-win.bat model.required_operators_and_types.with_runtime_opt.config` on Windows
+5. Run `./build-mac.sh model.required_operators_and_types.with_runtime_opt.config` on Mac or `.\build-win.bat model.required_operators_and_types.with_runtime_opt.config` on Windows, or `./build-linux.sh` on Linux
 
 6. The following files are ready to be used by consumer:
 

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -13,8 +13,8 @@ onnx_config="${1:-model.required_operators_and_types.config}"
 --enable_reduced_operator_type_support \
 --skip_tests
 
-# make-archive.sh expect the build process to but files in a lib directory s
-# that is included in the archive.
+# make-archive.sh expects the build process to put files in the ./lib directory
+# which is included in the archive.
 mkdir -p "lib"
 # using find to avoid cp stat errors with wildcards
 find ./onnxruntime/build/Linux_x86_64/MinSizeRel -name "libonnxruntime.so*" -exec cp {} lib/ \;

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -8,3 +8,9 @@
 --include_ops_by_config model.required_operators_and_types.config \
 --enable_reduced_operator_type_support \
 --skip_tests
+
+# make-archive.sh expect the build process to but files in a lib directory s
+# that is included in the archive.
+mkdir -p "lib"
+# using find to avoid cp stat errors with wildcards
+find ./onnxruntime/build/Linux_x86_64/MinSizeRel -name "libonnxruntime.so*" -exec cp {} lib/ \;

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
+
+# get onnx_config from parameter, or use default
+onnx_config="${1:-model.required_operators_and_types.config}"
+
 ./onnxruntime/build.sh \
 --config=MinSizeRel \
 --build_shared_lib \
 --parallel \
 --minimal_build \
 --disable_ml_ops --disable_exceptions --disable_rtti \
---include_ops_by_config model.required_operators_and_types.config \
+--include_ops_by_config "$onnx_config" \
 --enable_reduced_operator_type_support \
 --skip_tests
 

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -16,5 +16,8 @@ onnx_config="${1:-model.required_operators_and_types.config}"
 # make-archive.sh expects the build process to put files in the ./lib directory
 # which is included in the archive.
 mkdir -p "lib"
+# ar will create a single static library (libonnxruntime.a) in  ./lib
+ar -M <libonnxruntime.mri
+# also copy shared libary (for now?) into ./lib while we figure out linker errors in NeuralNote
 # using find to avoid cp stat errors with wildcards
-find ./onnxruntime/build/Linux_x86_64/MinSizeRel -name "libonnxruntime.so*" -exec cp {} lib/ \;
+find ./onnxruntime/build/Linux/MinSizeRel -name "libonnxruntime.so*" -exec cp {} lib/ \;

--- a/libonnxruntime.mri
+++ b/libonnxruntime.mri
@@ -1,0 +1,18 @@
+create lib/libonnxruntime.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnx.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnx_proto.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_common.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_flatbuffers.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_framework.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_graph.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_mlas.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_mocked_allocator.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_optimizer.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_providers.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_session.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_test_utils.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnxruntime_util.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnx_test_data_proto.a
+addlib onnxruntime/build/Linux/MinSizeRel/libonnx_test_runner_common.a
+save
+end


### PR DESCRIPTION
Modifying build-linux.sh to create the lib directory and shared library files needed by make-archive.sh.

build-linux builds a shared library. That library is now copied into the ./lib folder for make-archive.sh