### PR TITLE
Linux build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ model/*
 *.pyc
 onnxruntime-*
 onnxruntime.xcframework
+libonnxruntime.a
+libonnxruntime-neuralnote.tar.gz

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,10 +1,90 @@
-#!/bin/bash
-./onnxruntime/build.sh \
---config=MinSizeRel \
---build_shared_lib \
---parallel \
---minimal_build \
---disable_ml_ops --disable_exceptions --disable_rtti \
---include_ops_by_config model.required_operators_and_types.config \
---enable_reduced_operator_type_support \
---skip_tests
+#!/usr/bin/env bash
+set -euf -o pipefail
+
+onnx_config="${1:-model.required_operators_and_types.config}"
+
+build_arch() {
+	onnx_config="$1"
+	arch="$2"
+
+	CMAKE_BUILD_TYPE=MinSizeRel
+
+	python onnxruntime/tools/ci_build/build.py \
+	--build_dir "onnxruntime/build/linux_${arch}" \
+	--config=${CMAKE_BUILD_TYPE} \
+	--parallel \
+	--minimal_build \
+	--disable_ml_ops --disable_exceptions --disable_rtti \
+	--include_ops_by_config "$onnx_config" \
+	--enable_reduced_operator_type_support \
+	--cmake_extra_defines CMAKE_OSX_ARCHITECTURES="${arch}" \
+	--skip_tests
+
+    ar -M << EOF
+CREATE libonnxruntime.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/re2-build/libre2.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/google_nsync-build/libnsync_cpp.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/container/libabsl_hashtablez_sampler.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/container/libabsl_raw_hash_set.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/numeric/libabsl_int128.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/time/libabsl_civil_time.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/time/libabsl_time_zone.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/time/libabsl_time.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/profiling/libabsl_exponential_biased.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_throw_delegate.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_malloc_internal.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_raw_logging_internal.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_log_severity.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_base.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_spinlock_wait.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/debugging/libabsl_debugging_internal.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/debugging/libabsl_symbolize.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/debugging/libabsl_demangle_internal.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/debugging/libabsl_stacktrace.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/hash/libabsl_low_level_hash.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/hash/libabsl_city.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/hash/libabsl_hash.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/synchronization/libabsl_synchronization.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/synchronization/libabsl_graphcycles_internal.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/types/libabsl_bad_variant_access.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/types/libabsl_bad_optional_access.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/strings/libabsl_strings.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/strings/libabsl_cordz_info.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/strings/libabsl_cordz_handle.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/strings/libabsl_cord_internal.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/strings/libabsl_cord.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/strings/libabsl_cordz_functions.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/strings/libabsl_strings_internal.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/protobuf-build/libprotobuf.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/protobuf-build/libprotoc.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/protobuf-build/libprotobuf-lite.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/flatbuffers-build/libflatbuffers.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/pytorch_cpuinfo-build/libcpuinfo.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/_deps/pytorch_cpuinfo-build/deps/clog/libclog.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnx_test_runner_common.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_framework.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_providers.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/lib/libgtest.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/lib/libgmock.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_optimizer.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_flatbuffers.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_test_utils.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnx_test_data_proto.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_graph.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_mlas.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnx.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_common.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_session.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_util.a
+ADDLIB ./onnxruntime/build/linux_${arch}/${CMAKE_BUILD_TYPE}/libonnx_proto.a
+SAVE
+EOF
+}
+    
+build_arch "$onnx_config" x86_64
+
+mkdir -p "lib"
+mv libonnxruntime.a lib
+
+rm -f libonnx-neuralnote.tar.gz
+tar czf libonnxruntime-neuralnote.tar.gz include lib model.with_runtime_opt.ort model.ort

--- a/convert-model-to-ort.sh
+++ b/convert-model-to-ort.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #python -m tf2onnx.convert --saved-model model --output model.onnx --opset 13
 python -m onnxruntime.tools.convert_onnx_models_to_ort $1 --enable_type_reduction
 rm -rf ./model/
 mkdir -p ./model
 # python verify_model.py
-python -m bin2c -o ./model/model.ort model.ort
+python -m bin2c -o ./model/model.ort model.ort || bin2c > ./model/model.ort < model.ort


### PR DESCRIPTION
Necessary changes to build under Linux. Things I have changed:

- Ignore build outputs of Linux build in .gitignore
- Modify `build-linux.sh` to do a proper build, followed by building the combined static library using the `ar` tool
- Modify `/bin/bash` to `/usr/bin/env bash` in some places which should improve compatibility on certain Linux systems
- Use `bin2c` tool directly instead of Python module which was not available for me

The resulting `libonnxruntime-neuralnote.tar.gz` can then be used to build the NeuralNote plugin when (currently still manually) extracted into the correct places and built with the Linux based pull request I did in the other project.